### PR TITLE
Hard code number of rows and columns

### DIFF
--- a/NeuralProcessingTools/trialstructures.py
+++ b/NeuralProcessingTools/trialstructures.py
@@ -99,8 +99,8 @@ class OldWorkingMemoryTrials(TrialStructure):
                    }
 
     def __init__(self, *args, **kwargs):
-        self.ncols = 0
-        self.nrows = 0
+        self.ncols = 5
+        self.nrows = 5
         TrialStructure.__init__(self, *args, **kwargs)
 
     def load(self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name="NeuralProcessingTools",
-      version="0.7.0",
+      version="0.7.1",
       description="""Tools for processing neural data""",
       url="https://github.com/grero/NeuralProcessingTools.git",
       author="Roger Herikstad",


### PR DESCRIPTION
Fixes an error where, when number of rows and columns were obtained from the event_data itself, the number would be too low if not all combinations were presented for that session. This caused target labels to be mismatched across sessions. 